### PR TITLE
 [Anon] Black Grail: Field Shrine Equipment not selectable by Black G…

### DIFF
--- a/Black Grail.cat
+++ b/Black Grail.cat
@@ -714,7 +714,7 @@
             </modifier>
           </modifiers>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Field Shrine" hidden="true" id="6c98-78a7-474c-40e7" sortIndex="6">
+        <selectionEntry type="upgrade" import="true" name="Field Shrine" hidden="false" id="6c98-78a7-474c-40e7" sortIndex="6">
           <costs>
             <cost name="Glory Points" typeId="f3bb-a7e6-d476-f60b" value="2"/>
           </costs>
@@ -724,13 +724,6 @@
           <infoLinks>
             <infoLink name="Field Shrine" id="8ed7-b428-ee1b-a247" hidden="false" type="profile" targetId="76e2-0e5b-972a-0f69"/>
           </infoLinks>
-          <modifiers>
-            <modifier type="set" value="false" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="model" childId="3844-b41c-9ecc-85b9" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
         </selectionEntry>
         <selectionEntry type="upgrade" import="true" name="Broken Crown" hidden="true" id="ed7f-e91c-7eca-840a" sortIndex="3">
           <profiles>


### PR DESCRIPTION
 Updated field shrine to NOT only set hidden to false if the parent is a heretic trooper, and instead it's always visible (black grail doesn't have troopers anyhow, and all selections with the equipment group have the "can take any equipment")