### PR TITLE
Updated Yeoman to be able to replace a ranged weapon with a grenade

### DIFF
--- a/New Antioch.cat
+++ b/New Antioch.cat
@@ -992,21 +992,26 @@
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="8b4c-c5f4-f53b-fe48" shared="true"/>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="8e07-c816-38d7-7996" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="parent" childId="8b4c-c5f4-f53b-fe48" shared="true" includeChildSelections="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="parent" childId="8e07-c816-38d7-7996" shared="true" includeChildSelections="true"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="decrement" value="1" field="3265-f0db-dbe4-1366">
           <conditions>
-            <condition type="atLeast" value="2" field="selections" scope="parent" childId="8b4c-c5f4-f53b-fe48" shared="true"/>
+            <condition type="atLeast" value="2" field="selections" scope="parent" childId="8b4c-c5f4-f53b-fe48" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
         <modifier type="set" value="1" field="7702-1238-a0c1-bd75">
-          <conditions>
-            <condition type="instanceOf" value="1" field="selections" scope="model" childId="f2c3-86d1-5924-093f" shared="true"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="model" childId="f2c3-86d1-5924-093f" shared="true"/>
+                <condition type="equalTo" value="0" field="selections" scope="parent" childId="9c37-58de-3fa2-bfd2" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
     </selectionEntryGroup>


### PR DESCRIPTION
Updated Yeoman to be able to replace a ranged weapon with a grenade (they count as ranged weapons). From Discord:
_"For trench crusade yeoman new antioch, Grenades count as ranged weapons & should be allowed to switch their bolt action rifle for them but it's telling me it's an illegal action They only don't count towards number of ranged weapons you can carry but they are still a ranged weapon you can have"_

Set the minimum of ranged 1 weapons to 1 "if yeoman AND zero grenades" selected, instead of just "if yeoman".