### PR TITLE
Add additional relic option "Armour of Cobar" for Heretic Legion

### DIFF
--- a/Heretic Legion.cat
+++ b/Heretic Legion.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="6941-ec54-3001-8288" name="Heretic Legion" gameSystemId="sys-4f3d-c5c9-7df1-ad01" gameSystemRevision="1" revision="22" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="6941-ec54-3001-8288" name="Heretic Legion" gameSystemId="sys-4f3d-c5c9-7df1-ad01" gameSystemRevision="1" revision="23" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry type="model" import="true" name="Anointed Heavy Infantry" hidden="false" id="15bf-43f1-0650-1070" publicationId="c658-4a10-e1fe-befc" page="22">
       <costs>
@@ -3665,6 +3665,9 @@ When detonated, the mine explosion is treated as a BLAST 3” weapon targeting t
       <constraints>
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b24d-6016-dae3-c9f0" includeChildSelections="false"/>
       </constraints>
+      <entryLinks>
+        <entryLink import="true" name="Armour of Cobar" hidden="false" id="86ec-e64b-7792-8532" type="selectionEntry" targetId="4a11-8e06-0271-3973" sortIndex="6"/>
+      </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <forceEntries>
@@ -3677,17 +3680,6 @@ When detonated, the mine explosion is treated as a BLAST 3” weapon targeting t
       </categoryLinks>
     </forceEntry>
   </forceEntries>
-  <sharedProfiles>
-    <profile name="Test Weapon Number 3" typeId="090c-b12e-592a-9874" typeName="Weapon" hidden="false" id="2c1f-572b-b74f-a25c">
-      <characteristics>
-        <characteristic name="Type" typeId="f90e-171a-4ca6-3845">2-handed</characteristic>
-        <characteristic name="Range" typeId="31a7-b5e8-41dc-5fd1">Melee</characteristic>
-        <characteristic name="Modifiers" typeId="6977-37be-e105-b5aa">-</characteristic>
-        <characteristic name="Keywords" typeId="8cd6-8018-f2da-5ede">-</characteristic>
-        <characteristic name="Rules" typeId="6e95-3480-ad33-b345">-</characteristic>
-      </characteristics>
-    </profile>
-  </sharedProfiles>
   <sharedSelectionEntries>
     <selectionEntry type="upgrade" import="true" name="Bayonet Lug" hidden="false" id="3348-ed1b-adf7-af00">
       <costs>


### PR DESCRIPTION
I added a link to "Armour of Cobar" for Heretic Legion, according the compaign book they can use it. Also removedd "Test Weapon Number 3" from Shared Profiles, I guess it was some kind of artifact since game system files creation.
![image](https://github.com/user-attachments/assets/c2981598-3d2c-4258-90aa-b0ccf68eae0b)