### PR TITLE
Fix #445: Modify 'Gargantuan Size' upgrade description

### DIFF
--- a/Iron Sultanate.cat
+++ b/Iron Sultanate.cat
@@ -3584,7 +3584,7 @@ Hypnotic Eyes Alchemical Formulas.</characteristic>
               <profiles>
                 <profile name="Gargantuan Size" typeId="058c-866b-6487-ccc4" typeName="Ability" hidden="false" id="8cb2-f9e6-e496-1153">
                   <characteristics>
-                    <characteristic name="Description" typeId="2ecd-b4ff-9e78-a8e2">The Homunculus’ size is increased into vast proportions. Give this Takwin Homunculus the TOUGH Keyword and increase its base size to 50mm. A Homunculus cannot have the Massive Size Alchemical Formula if it has the Wings Alchemical Formula.</characteristic>
+                    <characteristic name="Description" typeId="2ecd-b4ff-9e78-a8e2">A Takwin Homunculus can only have this Alchemical Formula if it already has the Human Hands, Inhuman Strength, and Massive Size Alchemical Formulas. The Homunculus can use 1 Weapon that can usually only be taken by a Brazen Bull, and its base size is increased to 60mm.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>


### PR DESCRIPTION
Fixed an error in the description for 'Gargantuan Size' - the old description was a copy / paste of 'Massive Size'