### PR TITLE
Fix Keywords for Infernal Bomb characteristic

### DIFF
--- a/Heretic Legion.cat
+++ b/Heretic Legion.cat
@@ -852,7 +852,7 @@
           <characteristics>
             <characteristic name="Type" typeId="f90e-171a-4ca6-3845">1-Handed</characteristic>
             <characteristic name="Range" typeId="31a7-b5e8-41dc-5fd1">36&quot;</characteristic>
-            <characteristic name="Keywords" typeId="8cd6-8018-f2da-5ede">BLAST 3&quot;, IGNORE COVER, IGNORE ELEVATED POSITION, IGNORE LONG RANGE, RELOAD, SCATTER SHRAPNEL</characteristic>
+            <characteristic name="Keywords" typeId="8cd6-8018-f2da-5ede">BLAST 3&quot;, IGNORE COVER, IGNORE ELEVATED POSITION, IGNORE LONG RANGE, RELOAD, SCATTER, SHRAPNEL</characteristic>
             <characteristic name="Rules" typeId="87f0-637b-734a-22eb">* Duck: Add -1 INJURY DICE to the roll for a model that is hit by an Infernal Bomb if it is in contact with a terrain piece that is at least ½&quot; tall and that lies in between it and the target point. 
 
 * Infernal Strike: If the Success Roll for a Ranged Attack with an Infernal Bomb that targets an enemy model is a Success or a Critical Success, or if the attack is a Failure and the target point scatters onto a model&apos;s base, apply the effect of the DEADLY Keyword to the Injury Roll for that model. Injury Rolls for other models caught in the Infernal Bomb’s BLAST are made normally.


### PR DESCRIPTION
Updated the Keywords characteristic for Infernal Bomb. Added a missing comma in the keywords of the Artillery Witch - Infernal Bomb